### PR TITLE
Ref/handler: rename constructor

### DIFF
--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -55,7 +55,7 @@ func InitializeApp(cfg *config.Config) (*Application, error) {
 		userService.New,
 
 		// Handler providers
-		authHandler.NewHandler,
+		authHandler.New,
 		oauthHandler.New,
 		userHandler.New,
 

--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -56,7 +56,7 @@ func InitializeApp(cfg *config.Config) (*Application, error) {
 
 		// Handler providers
 		authHandler.NewHandler,
-		oauthHandler.NewHandler,
+		oauthHandler.New,
 		userHandler.New,
 
 		// HTTP server

--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -57,7 +57,7 @@ func InitializeApp(cfg *config.Config) (*Application, error) {
 		// Handler providers
 		authHandler.NewHandler,
 		oauthHandler.NewHandler,
-		userHandler.NewHandler,
+		userHandler.New,
 
 		// HTTP server
 		provideRouter,

--- a/internal/delivery/http/router.go
+++ b/internal/delivery/http/router.go
@@ -15,8 +15,8 @@ import (
 
 // NewRouter initializes the HTTP router and registers the routes for the application.
 // Swagger spec:
-// @title       Goth API
-// @BasePath    /v1
+// @title Goth API
+// @BasePath /v1
 // @securityDefinitions.apikey BearerAuth
 // @in header
 // @name Authorization

--- a/internal/domains/auth/handler/handler.go
+++ b/internal/domains/auth/handler/handler.go
@@ -15,7 +15,7 @@ type Handler struct {
 	validator *validator.Validate
 }
 
-func NewHandler(s service.AuthService, l logger.Interface, v *validator.Validate) *Handler {
+func New(s service.AuthService, l logger.Interface, v *validator.Validate) *Handler {
 	return &Handler{
 		service:   s,
 		logger:    l,

--- a/internal/domains/oauth/handler/handler.go
+++ b/internal/domains/oauth/handler/handler.go
@@ -22,7 +22,7 @@ type Handler struct {
 	validator *validator.Validate
 }
 
-func NewHandler(s service.OAuthService, l logger.Interface, v *validator.Validate) *Handler {
+func New(s service.OAuthService, l logger.Interface, v *validator.Validate) *Handler {
 	return &Handler{
 		service:   s,
 		logger:    l,

--- a/internal/domains/user/handler/handler.go
+++ b/internal/domains/user/handler/handler.go
@@ -22,7 +22,7 @@ type Handler struct {
 	logger  logger.Interface
 }
 
-func NewHandler(s service.UserService, l logger.Interface) *Handler {
+func New(s service.UserService, l logger.Interface) *Handler {
 	return &Handler{
 		service: s,
 		logger:  l,


### PR DESCRIPTION
This pull request refactors the naming convention for handler constructors across multiple modules to improve consistency and readability. The key changes involve renaming the `NewHandler` functions to `New` and updating their usage in the application initialization logic.

### Refactor of handler constructors:

* [`internal/domains/auth/handler/handler.go`](diffhunk://#diff-b8779be6ce799998364046a39b235b0c67ddf4c6009ddc3e36987cc47d67728cL18-R18): Renamed the `NewHandler` function to `New` in the `auth` handler module.
* [`internal/domains/oauth/handler/handler.go`](diffhunk://#diff-4b42aa88b9a0ef21d8d56f31024f27bb5fb55d8382651a9a19244065ab3c8c53L25-R25): Renamed the `NewHandler` function to `New` in the `oauth` handler module.
* [`internal/domains/user/handler/handler.go`](diffhunk://#diff-ac959934d6f312a9b954c504dc936348b4bdb41c8347523a1a8a71bc3a82249dL25-R25): Renamed the `NewHandler` function to `New` in the `user` handler module.

### Updates to application initialization:

* [`internal/app/wire.go`](diffhunk://#diff-57e8884a54f49ec45be1c189f3b59fce317776136a7a9ca431a9610b782ece14L58-R60): Updated the `InitializeApp` function to use the renamed `New` constructors for `authHandler`, `oauthHandler`, and `userHandler`.