### PR TITLE
chore: update Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ cp .env.example .env
 docker compose up -d
 ```
 
+4. Run the migrations:
+
+```bash
+make migrate.up
+```
+
 ### Dev
 
 For development, you can use Air for hot reloading:


### PR DESCRIPTION
This pull request introduces several updates to the `Makefile` and `README.md` to enhance database migration management and improve developer guidance. Key changes include the addition of new Makefile targets for database migrations, updates to instructions for generating domain structures, and improvements to the project setup documentation.

### Database Migration Enhancements:
* Added new Makefile targets for managing database migrations, including `migrate.up`, `migrate.down`, `migrate.step-up`, `migrate.step-down`, `migrate.create`, and `migrate.force`. These targets streamline migration operations and provide clear prompts for required variables such as `dsn`, `name`, and `version`.

### Developer Guidance Improvements:
* Updated the `generate.domains` target in the `Makefile` to include additional guidance for developers, such as an example usage of the `domains` variable and a prompt to edit `schema.sql` and `queries.sql` files after generating a domain structure. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R28) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R52)
* Added a step in the `README.md` to instruct developers to run database migrations after setting up the project, improving clarity for new users.

### Dependency Management:
* Removed the installation of `sqlc` from the `deps.bin` target in the `Makefile`, possibly reflecting a change in project dependencies or tooling.