### PR TITLE
fix(ci): update supported platforms in GitHub CI configuration

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -76,5 +76,5 @@ jobs:
         with:
             context: .
             push: true
-            platforms: linux/amd64,linux/arm/v7,linux/arm64
+            platforms: linux/amd64,linux/arm64
             tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.sha }}


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration. The change removes the `linux/arm/v7` platform from the list of supported platforms for the Docker build process.

* [`.github/workflows/github-ci.yaml`](diffhunk://#diff-1102636ac9e880a77a4653d32977a3ec33fd7d932d491fd8ce99d95e21de229bL79-R79): Updated the `platforms` field in the `jobs` section to exclude `linux/arm/v7`, leaving only `linux/amd64` and `linux/arm64` as supported platforms.